### PR TITLE
Confirmed working compilation on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,18 @@ QUPS is intended to be an abstract, lightweight, readable tool for simulation an
 The easiest way to get started is to open and run [`example.mlx`](example.mlx) or [`example_.m`](example_.m) and interact with the simulation and beamforming examples. There are plenty of comments highlighting the different methods supported by the interface. You will need to separately download the simulator packages that you wish to use. Don't forget to add them to your path!
 
 ### Compatibility
-QUPS targets MATLAB R2020b and later on linux. While it may work for older versions of MATLAB, you may get strange errors that don't appear in later versions. QUPS does minimal error checking for compatibility in order to maintain flexibility.
+QUPS targets MATLAB R2020b and later on Linux. While it may work for older versions of MATLAB, you may get strange errors that don't appear in later versions. QUPS does minimal error checking for compatibility in order to maintain flexibility.
 
-If you have trouble, please submit an [issue](https://github.com/thorstone25/qups/issues).
+#### Windows Compilation
+Compilation on Windows has been tested with the following dependencies:
+* Windows 10 x64
+* Matlab R2020a
+* CUDA 10.2 and associated samples
+* Visual Studio 2017
+
+During initial setup, the user will be prompted to point to the appropriate paths to assist with compilation of the underlying CUDA binaries. 
+
+If you have trouble compiling on any platform, please submit an [issue](https://github.com/thorstone25/qups/issues).
 
 ## Documentation
 QUPS is (partially) internally documented following MATLAB conventions. This means you can use `doc` on any class and `help` on any class or method with `help classname/methodname` or `help classname.methodname`.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ QUPS objects, classes, and functions adhere to some conventions to make prototyp
 | Angle | Degrees |
 
 #### Dimensions
- 
+
 | Property | Standard | 
 | ------ | ------ |
 | Position | {x,y,z} in dimension 1 |
@@ -59,11 +59,10 @@ Note that this transmit sequence definition is likely to result in data with var
 #### Broadcasting
 Utilities are provided to assist in writing readable, broadcasting code. The `sub` utility allows you to conveniently slice one dimension while the utility `swapdim`  as well as the built-in `shiftdim` and `permute` functions are useful for placing data in broadcasting dimensions.
 
-Dimensions are used to implicitly broadcast operations, allowing you to limit memory and computational demand for simple workflows. For example, the apodization argument for the `DAS` method takes in an argument of size I1 x I2 x I3 x N x M where {I1,I2,I3} is the size of the scan, N is the number of receivers, and M is the number of transmits. This can be a huge array, easily over 100GB! However, in many cases we may only need 2 or 3 of these dimensions. 
+Dimensions are used to implicitly broadcast operations, allowing you to limit memory and computational demand for simple workflows. For example, the apodization argument for the `DAS` method takes in an argument of size $I_1 \times I_2 \times I_3 \times N \times M$ where $\{I_1,I_2,I_3\}$ is the size of the scan, $N$ is the number of receivers, and $M$ is the number of transmits. This can be a huge array, easily over 100GB! However, in many cases we may only need 2 or 3 of these dimensions. 
 
-For example, to evaluate a multi-monostatic configuration given a set of FSA data, we simply create an array of size 1 x 1 x 1 x N x M and apply identity matrix weights.
+For example, to evaluate a multi-monostatic configuration given a set of FSA data, we simply create an array of size $1 \times 1 \times 1 \times N \times M$ and apply identity matrix weights.
 ```
 apod = shiftdim( (1:N)' == (1:M), -3); % we can leave this as a binary type!
 ```
-
 

--- a/src/UltrasoundSystem.m
+++ b/src/UltrasoundSystem.m
@@ -2082,8 +2082,18 @@ classdef UltrasoundSystem < handle
                     ));
                 
                 try
-                    s = system(com);
-                    if s, warning("Error recompiling code!"); else, disp("Success recompiling " + d.Source); end
+                    [s,out] = system(com);
+                    if s 
+                        warning("Error recompiling code!"); 
+                        if ~false % Verbosity toggle
+                            warning("CMD:");
+                            warning(com);
+                            disp();
+                            warning("OUTPUT:");
+                            warning(out);
+                        end
+                    else, disp("Success recompiling " + d.Source);
+                    end
                 catch
                     warning("Unable to recompile code!");
                 end

--- a/src/UltrasoundSystem.m
+++ b/src/UltrasoundSystem.m
@@ -2121,7 +2121,11 @@ classdef UltrasoundSystem < handle
             if isunix()
                 f = '/usr/local/cuda';
             else
-                error("No known default CUDA folder");
+                try
+                    f = uigetdir('C:/Program Files/','Path to CUDA Root (containing (bin/)');
+                catch
+                    error("No known default CUDA folder");
+                end
             end
         end
 

--- a/src/UltrasoundSystem.m
+++ b/src/UltrasoundSystem.m
@@ -2071,24 +2071,25 @@ classdef UltrasoundSystem < handle
             for d = defs
                 % make full command
                 com = join(cat(1,...
-                    fullfile(cuda_folder,'bin/nvcc'), ...
-                    ['--ptx ' fullfile(src_folder, [d.Source])], ...
-                    ['-o ' fullfile(self.tmp_folder, strrep(d.Source, 'cu', 'ptx'))], ...
+                    escapeSpaces(fullfile(cuda_folder,'bin/nvcc')), ...
+                    d.ccbin,... for Windows
+                    ['--ptx ' escapeSpaces(fullfile(src_folder, [d.Source]))], ...
+                    ['-o ' escapeSpaces(fullfile(self.tmp_folder, strrep(d.Source, 'cu', 'ptx')))], ...
                     join("--" + d.CompileOptions),...
-                    join("-I" + d.IncludePath), ...
-                    join("-L" + d.Libraries), ...
+                    join("-I" + escapeSpaces(d.IncludePath)), ...
+                    join("-L" + escapeSpaces(d.Libraries)), ...
                     join("-W" + d.Warnings), ...
                     join("-D" + d.DefinedMacros)...
                     ));
                 
                 try
-                    [s,out] = system(com);
+                    [s,out] = system(char(com));
                     if s 
                         warning("Error recompiling code!"); 
                         if ~false % Verbosity toggle
                             warning("CMD:");
                             warning(com);
-                            disp();
+                            warning(' ');
                             warning("OUTPUT:");
                             warning(out);
                         end
@@ -2124,32 +2125,68 @@ classdef UltrasoundSystem < handle
             f = fileparts(mfilename('fullpath'));
         end
         
-        function f = getDefaultCUDAFolder()
-            %
+        function [f,f_samp] = getDefaultCUDAFolder()
+            % Environment variables could be problematic on Windows systems
+            % with multiple Cuda Installs (Not aware of Windows LMOD equivalent)
+            % Using manual definitions instead.
+            
+            %% Path Caching
+            % For some reason Matlab doesn't like making f & f_samp
+            % persistent...
+            persistent f_tmp f_samp_tmp;
 
-            % TODO: search for CUDA via environmental variables
-            if isunix()
-                f = '/usr/local/cuda';
-            else
-                try
-                    f = uigetdir('C:/Program Files/','Path to CUDA Root (containing (bin/)');
-                catch
-                    error("No known default CUDA folder");
+            %% Default Paths
+            if isempty(f_tmp)
+                if isunix()
+                    f = '/usr/local/cuda';
+                    f_samp = fullfile(f,'samples');
+                else
+                    f = 'C:/Program Files/';
+                    f_samp = 'C:\ProgramData\NVIDIA Corporation\CUDA Samples\';
                 end
+            else % Load cached paths
+                f=f_tmp;
+                f_samp=f_samp_tmp;
             end
+            
+            %% Manual Path Lookup
+            try
+                assert(exist(fullfile(f,'bin'),'file')==7,...
+                'CUDA path does not contain bin/.  Double check definition')
+            catch
+                f = uigetdir(f,'Path to CUDA Root (containing (bin/)');
+            end
+            try
+                assert(exist(fullfile(f_samp,'0_Simple/'),'file')==7,...
+            'CUDA Samples path does not contain 0_Simple/.  Double check definition')
+            catch
+                f_samp = uigetdir(f_samp,'Path to CUDA Samples (containing (0_Simple/)');
+            end
+            
+            %% Final sanity checks in case of PEBKAC
+            assert(exist(fullfile(f,'bin'),'file')==7,...
+                'CUDA path does not contain bin/.  Double check definition')
+            assert(exist(fullfile(f_samp,'0_Simple/'),'file')==7,...
+            'CUDA path does not contain 0_Simple/.  Double check definition')
+            
+            %% Cache variable for future runs
+            f_tmp = f;
+            f_samp_tmp = f_samp;
         end
 
-        function d = genCUDAdef_beamform(cuda_folder)
-            % no halp :(
+        function d = genCUDAdef_beamform(cuda_folder,cuda_samples)
 
             % CUDA folder
-            if nargin < 1, cuda_folder = UltrasoundSystem.getDefaultCUDAFolder(); end
+            if nargin < 1, [cuda_folder,cuda_samples] = UltrasoundSystem.getDefaultCUDAFolder(); end
 
             % filename
             d.Source = 'bf.cu';
-
+            if ~exist('cuda_samples','var')
+                cuda_samples = fullfile(cuda_folder,'samples'); % Ubuntu default
+            end
             d.IncludePath = {... include folders
-                fullfile(cuda_folder, 'samples/common/inc'), ...
+                
+                fullfile(cuda_samples, 'common/inc'), ...
                 };
 
             d.Libraries = {...
@@ -2159,6 +2196,23 @@ classdef UltrasoundSystem < handle
             d.CompileOptions = {...  compile options
                 "use_fast_math",...
                 };
+            d.ccbin = [];
+            if ispc
+                %% Need to manually link to Visual Studio binary
+                % Probably a better way to do this, but it works
+                % Tested in VS 2017
+                persistent ccbin
+                if ~(exist(ccbin,'file')==2)
+                    [fn,fp] = uigetfile('cl.exe',...
+                    'Visual Studio path: <VS>/<year>/Community/VC/Tools/MSVC/*/bin/Hostx64/x64/cl.exe',...
+                    'C:/Program Files (x86)');
+                    fpn = fullfile(fp,fn);
+                    assert(exist(fpn,'file')==2,'cl.exe not found. Check Visual Studio Path');
+                    ccbin = sprintf('%s',fpn);
+                end
+                % d.CompileOptions{end+1} = ['ccbin ' escapeSpaces(ccbin)]; % Doesn't work, requires 1 dash
+                d.ccbin = [' -ccbin ' escapeSpaces(ccbin)];
+            end
 
             d.Warnings = {... warnings
                 "no-deprecated-gpu-targets"...
@@ -2192,6 +2246,22 @@ classdef UltrasoundSystem < handle
             % generate for msfms3d - same files, different structure
             d(2).Source = 'msfm3d.c';
         end
+    end
+end
+
+% Ain't nobody got time for pointless OOP scoping shenanigans...
+function out_str = escapeSpaces(in_str)
+    esc = @(s) sprintf('"%s"',s);
+    switch class(in_str)
+        case 'char'
+            out_str = esc(in_str);
+        case 'string'
+            % Reshaping is for string arrays
+            out_str=reshape(esc(in_str(:)),size(in_str)); 
+        case 'cell'
+            out_str = cellfun(esc,in_str,'UniformOutput',false);
+        otherwise
+            error('Unsupported class %s', class(in_str))
     end
 end
 

--- a/src/helper_math.h
+++ b/src/helper_math.h
@@ -1603,6 +1603,11 @@ inline __device__ __host__ double clamp(double f, double a, double b)
 {
     return fmax(a, fmin(f, b));
 }
+inline __device__ __host__ double clamp(double f, float a, float b)
+{ // Windows hack
+    return clamp(f,double(a),double(b));
+}
+
 inline __device__ __host__ int clamp(int f, int a, int b)
 {
     return max(a, min(f, b));


### PR DESCRIPTION
This works by essentially prompting the user for the relevant paths to the directories, which should be relatively general for both Windows and *nix systems.  The code is easily hackable by the end-user to avoid this behavior should they find that annoying.

In addition to the compilation system the following additions were made:
* A Bugfix in helper_math.h due to an ambiguous overloaded function definition for `clamp()`
* An additional flag `-ccbin` was added to ensure compatibility with Visual Studio MSVC compilers.
* Mathjax syntax was added to the Readme for readability
* Space handling of Windows paths
* Guaranteed path validation checks keying off the existence of expected subdirectories.